### PR TITLE
Retry fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -420,9 +420,25 @@ exports.auto = function(tasks) {
 };
 
 exports.retry = function(times, task) {
-	callbackTask = constructIterator(task, 0, true, false);
+	var timesObject = {
+		times: 5,
+		interval: 0
+	}
+
+	// Respect defaults
+	if(typeof times === 'function') {
+		console.log('times is a function: ' + times);
+		callbackTask = constructIterator(times, 0, true, false);
+	} else {
+		if(typeof times === 'object') {
+			timesObject = times;
+		} else if(typeof times == 'number') {
+			timesObject.times = times;
+		}
+		callbackTask = constructIterator(task, 0, true, false);
+	}
 	return new Promise(function(resolve, reject) {
-		async.retry(times, callbackTask, function(err, result) {
+		async.retry({times: 3}, callbackTask, function(err, result) {
 			if(err) {
 				reject(err);
 			} else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -420,25 +420,18 @@ exports.auto = function(tasks) {
 };
 
 exports.retry = function(times, task) {
-	var timesObject = {
-		times: 5,
-		interval: 0
-	}
-
-	// Respect defaults
+	// Respect defaults by checking if no times is passed, or if it is passed as an object
 	if(typeof times === 'function') {
 		console.log('times is a function: ' + times);
-		callbackTask = constructIterator(times, 0, true, false);
-	} else {
-		if(typeof times === 'object') {
-			timesObject = times;
-		} else if(typeof times == 'number') {
-			timesObject.times = times;
-		}
-		callbackTask = constructIterator(task, 0, true, false);
+		task = times;
+		times = 5;
+	} else if(typeof times === 'object') {
+		console.log('times is an object: ' + times);
+		times = times.times;
 	}
+	callbackTask = constructIterator(task, 0, true, false);
 	return new Promise(function(resolve, reject) {
-		async.retry({times: 3}, callbackTask, function(err, result) {
+		async.retry(times, callbackTask, function(err, result) {
 			if(err) {
 				reject(err);
 			} else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -422,11 +422,9 @@ exports.auto = function(tasks) {
 exports.retry = function(times, task) {
 	// Respect defaults by checking if no times is passed, or if it is passed as an object
 	if(typeof times === 'function') {
-		console.log('times is a function: ' + times);
 		task = times;
 		times = 5;
 	} else if(typeof times === 'object') {
-		console.log('times is an object: ' + times);
 		times = times.times;
 	}
 	callbackTask = constructIterator(task, 0, true, false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pasync",
-  "version": "1.1.0",
+  "version": "1.2.0",
+  "license": "MIT",
   "description": "Promise-oriented async",
   "main": "./lib/index.js",
   "repository": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -967,6 +967,32 @@ describe('pasync', function() {
 		}).catch(done);
 	});
 
+	it('retry with just task', function(done) {
+		var responseArray = [];
+		var retry = pasync.retry(function() {
+			responseArray.push('a');
+			responseArray.push('b');
+			responseArray.push('c');
+			return Promise.resolve();
+		}).then(function() {
+			expect(responseArray).to.deep.equal(['a', 'b', 'c']);
+			done();
+		}).catch(done);
+	});
+
+	it('retry with object as first argument', function(done) {
+		var responseArray = [];
+		var retry = pasync.retry({times: 4, interval: 7}, function() {
+			responseArray.push('a');
+			responseArray.push('b');
+			responseArray.push('c');
+			return Promise.resolve();
+		}).then(function() {
+			expect(responseArray).to.deep.equal(['a', 'b', 'c']);
+			done();
+		}).catch(done);
+	});
+
 	it('retry with error', function(done) {
 		var retryCount = 0;
 		var retry = pasync.retry(3, function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1007,6 +1007,34 @@ describe('pasync', function() {
 		}).catch(done);
 	});
 
+	it('retry with error and just task', function(done) {
+		var retryCount = 0;
+		var retry = pasync.retry(function() {
+			retryCount++;
+			return Promise.reject(123);
+		}).then(function() {
+			throw new Error('should not reach');
+		}, function(err) {
+			expect(err).to.equal(123);
+			expect(retryCount).to.equal(5);
+			done();
+		}).catch(done);
+	});
+
+	it('retry with error and object as first param', function(done) {
+		var retryCount = 0;
+		var retry = pasync.retry({times: 4, interval: 7}, function() {
+			retryCount++;
+			return Promise.reject(123);
+		}).then(function() {
+			throw new Error('should not reach');
+		}, function(err) {
+			expect(err).to.equal(123);
+			expect(retryCount).to.equal(4);
+			done();
+		}).catch(done);
+	});
+
 	it('apply', function(done) {
 	var arr = [0, 1, 2];
 		var responseArray = [];


### PR DESCRIPTION
Add support for default retry of 5 when called with just a function. Fixes #24 

Will update retry with opt param when it is in an npm release.